### PR TITLE
Revoke certificates for NSS based applications

### DIFF
--- a/Linux/README.md
+++ b/Linux/README.md
@@ -1,0 +1,39 @@
+Revoke-China-Certs on Linux
+==========================================
+
+## Intro
+
+This tool revokes certain CA certificates for NSS-based applications on Linux,
+(most notably, Firefox & Chrome).
+
+On Linux there are multiple libraries for SSL/TLS and each may have its own
+certificate store. The `/etc/ca-certificate.conf` configures the trusted
+Root CAs for OpenSSL (which `wget` uses by default). Another widely used
+library is NSS by Mozilla, which supports blacklisting a specific intermediate
+CA without fiddling with the Root CA.
+
+**This tool is experimental. DO MAKE BACKUPS before you do anything!**
+
+## Usage
+
+First you need to have packages installed to provide `certutil`. On Ubuntu it would be:
+
+        sudo apt-get install libnss3-tools
+
+Then, use the `revoke-china-certs.sh` to do the revocation. For Chrome it would be:
+
+        ./revoke-china-certs.sh extended $HOME/.pki/nssdb
+
+to revoke trust of CAs within the *extended* set. Change `extended` to `all` or `base`
+or `restore` to revoke other sets of certs.
+
+Since Firefox maintains different certificate store for different browser profile (rather
+than per Linux user for Chrome), you need to do this for every profile under `~/.mozilla/firefox`.
+
+        for profile in `ls ~/.mozilla/firefox/*.default`;do
+            ./revoke-china-certs.sh extended $HOME/.mozilla/firefox/$profile
+        done
+
+## Notes
+
+Deselecting a CA by `dpkg-reconfigure ca-certificates` does NOT affect any NSS-based applications.

--- a/Linux/nss_revoke.sh
+++ b/Linux/nss_revoke.sh
@@ -3,11 +3,20 @@
 DBPATH=$1
 CERTS=$2
 
+
+echo "Resetting CA set"
+RESETS=``
+
+certutil -d sql:${DBPATH} -L | grep -oP "NSS Certificate DB:revoke-china-certs:[^\s]+" | \
+while read CERT;do
+    certutil -d sql:${DBPATH} -D -n "${CERT}"
+done
+
 echo "Revoking CAs in $DBPATH/cert9.db"
 
 for CERT in $CERTS;do
     # p,p,p: prohibit all use
-    certutil -d sql:${DBPATH} -A -n "${CERT}" -t p,p,p -i ${CERT}
+    certutil -d sql:${DBPATH} -A -n "revoke-china-certs:${CERT}" -t p,p,p -i ${CERT}
 done
 
 echo "Done"

--- a/Linux/nss_revoke.sh
+++ b/Linux/nss_revoke.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+DBPATH=$1
+CERTS=$2
+
+echo "Revoking CAs in $DBPATH/cert9.db"
+
+for CERT in $CERTS;do
+    # p,p,p: prohibit all use
+    certutil -d sql:${DBPATH} -A -n "${CERT}" -t p,p,p -i ${CERT}
+done
+
+echo "Done"

--- a/Linux/revoke-china-certs.sh
+++ b/Linux/revoke-china-certs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+if [ ${1:-extended} = 'all' ];then
+    echo "Generating ALL CRL set"
+    # TODO: Explicitly distinguish between CA & EE certificates.
+    CA_CERTS=`ls ../Windows/Certs/Online/*.crt`
+    EE_CERTS=`ls ../Windows/Certs/Online/\[Fake\]*.crt`
+    echo "all"
+elif [ ${1:-extended} = 'extended' ];then
+    echo "Generating EXTENDED CRL set"
+    CA_CERTS=`ls ../Windows/Certs/Online/CNNIC_*.crt ../Windows/Certs/Online/China_Internet_Network_Information_Center_EV_Certificates_Root.crt ../Windows/Certs/Online/[Suspicious]WaccBaiduCom.crt ../Windows/Certs/Online/GiantRootCA.crt ../Windows/Certs/Online/CFCA_*.crt  ../Windows/Certs/Online/UCA_*.crt  ../Windows/Certs/Online/[Suspicious]GoAgent_CA.crt`
+    EE_CERTS=`ls ../Windows/Certs/Online/\[Fake\]*.crt`
+elif [ ${1:-extended} = 'restore' ];then
+    echo "Generating RESTORE CRL set"
+    CA_CERTS=''
+    EE_CERTS=''
+else
+    echo "Generating Basic CRL set"
+    CA_CERTS=`ls ../Windows/Certs/Online/CNNIC_*.crt ../Windows/Certs/Online/China_Internet_Network_Information_Center_EV_Certificates_Root.crt ../Windows/Certs/Online/[Suspicious]WaccBaiduCom.crt ../Windows/Certs/Online/GiantRootCA.crt`
+    EE_CERTS=`ls ../Windows/Certs/Online/\[Fake\]*.crt`
+fi
+
+CERTS=`echo $CA_CERTS $EE_CERTS`
+./nss_revoke.sh ${2:-~/.pki/nssdb} "${CERTS}"


### PR DESCRIPTION
Which should work for Firefox & Chrome.

(Also it's worth noting in the main README that `dpkg-reconfigure ca-certificates` does NOT affect Firefox & Chrome.)