### PR TITLE
Remove root{1,2}evtest.wosign.com since they have been expired

### DIFF
--- a/Linux/validator.sh
+++ b/Linux/validator.sh
@@ -14,9 +14,7 @@ extended() {
     "$SOURCE_DIR/../Mac/test/test-url.sh" \
       https://www.gdca.com.cn/ \
       https://cs.cfca.com.cn/ \
-      https://www.wosign.com/ \
-      https://root1evtest.wosign.com/ \
-      https://root2evtest.wosign.com/
+      https://www.wosign.com/
 }
 
 all() {

--- a/Mac/test/test-url-list.txt
+++ b/Mac/test/test-url-list.txt
@@ -3,8 +3,6 @@ https://wacc.n.shifen.com/
 https://www.gdca.com.cn/
 https://cs.cfca.com.cn/
 https://www.wosign.com/
-https://root1evtest.wosign.com/
-https://root2evtest.wosign.com/
 https://www.hongkongpost.hk/
 https://epki.com.tw/
 https://www.twca.com.tw/

--- a/Shared/Documents/ReadMe_Online.md
+++ b/Shared/Documents/ReadMe_Online.md
@@ -91,7 +91,7 @@ TÜRKTRUST Elektronik Sertifika Hizmet Sağlayıcısı H6 | [TÜRKTRUST](https:/
 Name | Authority | Fingerprint
 :---:|:---:|---
 CA WoSign ECC Root | [WoSign CA Limited](https://www.wosign.com) | D27AD2BEED94C0A13CC72521EA5D71BE8119F32B
-[CA 沃通根证书](https://root2evtest.wosign.com) | [WoSign CA Limited](https://www.wosign.com) | 1632478D89F9213A92008563F5A4A7D312408AD6
+CA 沃通根证书 | [WoSign CA Limited](https://www.wosign.com) | 1632478D89F9213A92008563F5A4A7D312408AD6
 CA 沃通根证书 | [StartCom Certification Authority](https://www.startcomca.com) | B2FBDA222493A93C38F77C90D4BE6DA17F15F0B0
 CA 沃通根证书 | [StartCom Certification Authority](https://www.startcomca.com) | CE335662F0EA6764B95C7F50A995A514ACE8C815
 CA 沃通根证书 | [StartCom Certification Authority](https://www.startcomca.com) | D8EFF6C28BB508E4702565F42748454A872BD412


### PR DESCRIPTION
The following sites in the validator list have certificates that have been expired:
* root1evtest.wosign.com
* root2evtest.wosign.com

Therefore, they seem to lower the accuracy of the validators. Removing them would be a choice.